### PR TITLE
suppress mongoose strictQuery warning

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -24,6 +24,7 @@ app.use(cors());
 dotenv.config();
 
 //db
+mongoose.set('strictQuery', true);
 mongoose.connect(process.env.DB_URL);
 db.on("error", (error) => {
   console.log(error);


### PR DESCRIPTION
strictQuery would be disabled in the future (Mongoose 7).
Therefore (currently default) strictQuery should be enabled explicitly 